### PR TITLE
ci: bump Swift SDK to swift-wasm-DEVELOPMENT-SNAPSHOT-2024-04-26-a

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-main-jammy@sha256:6992010c6c7564b6f09ea7905f8bd89e950afd95a288a85ad092dde07f32a5c1
+    container: swiftlang/swift:nightly-main-jammy@sha256:216e18ce64ce5f3971f7b381066799acbd61bc34cdcc27f6b251fa299538c1dd
     env:
       STACK_SIZE: 16777216
     steps:
@@ -15,6 +15,6 @@ jobs:
       - uses: bytecodealliance/actions/wasmtime/setup@v1
       - run: swift --version
       - run: wasmtime -V
-      - run: swift experimental-sdk install https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-04-19-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-04-19-a-wasm32-unknown-wasi.artifactbundle.zip
+      - run: swift experimental-sdk install https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-04-26-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-04-26-a-wasm32-unknown-wasi.artifactbundle.zip
       - run: swift build -c release --build-tests --experimental-swift-sdk wasm32-unknown-wasi -Xlinker -z -Xlinker stack-size=$STACK_SIZE
       - run: wasmtime --dir / --wasm max-wasm-stack=$STACK_SIZE .build/release/swift-syntaxPackageTests.wasm


### PR DESCRIPTION
https://github.com/swiftwasm/swift/releases/tag/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-04-26-a