### PR TITLE
ci: bump Swift SDK to swift-wasm-DEVELOPMENT-SNAPSHOT-2024-09-07-a

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,13 +5,13 @@ on:
   pull_request:
     branches: ["wasm32-wasi-test"]
 env:
-  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-08-30-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-08-30-a-wasm32-unknown-wasi.artifactbundle.zip
-  SWIFT_SDK_CHECKSUM: e2865f6c1b948c355c858671408cafb6b7a16c2a5d36d64b0176bd183f8cceff
+  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-09-07-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-09-07-a-wasm32-unknown-wasi.artifactbundle.zip
+  SWIFT_SDK_CHECKSUM: dd43e067cccee3051b5fee16b5b2850943e57aea216948b4934a97b11901bfc2
   TARGET_TRIPLE: wasm32-unknown-wasi
 jobs:
   test:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-main-jammy@sha256:f402bf92ef7612b0467562b563e432a0b97614508502cfeb6585e4b024941bb8
+    container: swiftlang/swift:nightly-main-jammy@sha256:c47105d85d7d62b5e746ad1374fed57d5ede38b4819d9a493d75b382ea3a2021
     env:
       STACK_SIZE: 16777216
     steps:


### PR DESCRIPTION
https://github.com/swiftwasm/swift/releases/tag/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-09-07-a