### PR TITLE
ci: pin wasmtime version to 24.0.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: bytecodealliance/actions/wasmtime/setup@v1
+        with:
+          version: "24.0.0"
       - run: swift --version
       - run: wasmtime -V
       - run: swift sdk install $SWIFT_SDK_URL --checksum $SWIFT_SDK_CHECKSUM


### PR DESCRIPTION
I've used the latest wasmtime in the CI, but that sometimes broke the CI, so I'm going to pin its version.