### PR TITLE
ci: bump wasmtime to 27.0.0

### DIFF
--- a/.github/workflows/swiftwasm.yml
+++ b/.github/workflows/swiftwasm.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: bytecodealliance/actions/wasmtime/setup@v1
         with:
-          version: "26.0.1"
+          version: "27.0.0"
       - run: swift --version
       - run: wasmtime -V
       - run: swift sdk install $SWIFT_SDK_URL --checksum $SWIFT_SDK_CHECKSUM


### PR DESCRIPTION
https://github.com/bytecodealliance/wasmtime/releases/tag/v27.0.0