### PR TITLE
ci: bump Swift SDK to swift-wasm-DEVELOPMENT-SNAPSHOT-2024-11-24-a

### DIFF
--- a/.github/workflows/swiftwasm.yml
+++ b/.github/workflows/swiftwasm.yml
@@ -5,13 +5,13 @@ on:
   pull_request:
     branches: ["wasm32-wasi-test"]
 env:
-  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-11-21-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-11-21-a-wasm32-unknown-wasi.artifactbundle.zip
-  SWIFT_SDK_CHECKSUM: d945b062b8ee2e6bfcfd9c78d5d7b51c9d7edbef47c94766061564854e934eea
+  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-11-24-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-11-24-a-wasm32-unknown-wasi.artifactbundle.zip
+  SWIFT_SDK_CHECKSUM: 2c601b5da42659cf54176df4c0c5f48b0da8b0ad11647531143e5aec058d45c1
   TARGET_TRIPLE: wasm32-unknown-wasi
 jobs:
   test:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-main-jammy@sha256:21b177ee80c31be6523d1ae1b02c9bb0716b5bcd21796d67e33d7514f5653aa1
+    container: swiftlang/swift:nightly-main-jammy@sha256:0441267bc90fba42e25c608386845b81a0a0fcd2789c0efe84e2eff50aab8614
     env:
       STACK_SIZE: 16777216
     steps:


### PR DESCRIPTION
https://github.com/swiftwasm/swift/releases/tag/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-11-24-a