### PR TITLE
ci: bump wasmtime to 28.0.1

### DIFF
--- a/.github/workflows/swiftwasm.yml
+++ b/.github/workflows/swiftwasm.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: bytecodealliance/actions/wasmtime/setup@v1
         with:
-          version: "28.0.0"
+          version: "28.0.1"
       - run: swift --version
       - run: wasmtime -V
       - run: swift sdk install $SWIFT_SDK_URL --checksum $SWIFT_SDK_CHECKSUM


### PR DESCRIPTION
https://github.com/bytecodealliance/wasmtime/releases/tag/v28.0.1