### PR TITLE
ci: bump Swift SDK to swift-wasm-DEVELOPMENT-SNAPSHOT-2025-01-11-a

### DIFF
--- a/.github/workflows/swiftwasm.yml
+++ b/.github/workflows/swiftwasm.yml
@@ -5,13 +5,13 @@ on:
   pull_request:
     branches: ["wasm32-wasi-test"]
 env:
-  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-01-06-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-01-06-a-wasm32-unknown-wasi.artifactbundle.zip
-  SWIFT_SDK_CHECKSUM: d0bc0992329b5a9772e5c9ab44d5fb90aa568b1886406161ad58b9c53d76bcba
+  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-01-11-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-01-11-a-wasm32-unknown-wasi.artifactbundle.zip
+  SWIFT_SDK_CHECKSUM: c9b4f4c16015d196e565105a74bf39432f8ba8139c390052b221a5c12fcaf9be
   TARGET_TRIPLE: wasm32-unknown-wasi
 jobs:
   test:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-main-jammy@sha256:b26b5ba54743fe2ef662b1aa0cd2ec23f4c9e35ddc15c6a1aca4a772481236a4
+    container: swiftlang/swift:nightly-main-jammy@sha256:8ab66fcdb8adcf08228b94c52317cd6dc1e50b65f87d4cd99eacb641ce27880e
     env:
       STACK_SIZE: 16777216
     steps:


### PR DESCRIPTION
https://github.com/swiftwasm/swift/releases/tag/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-01-11-a