### PR TITLE
ci: bump Swift SDK to swift-wasm-DEVELOPMENT-SNAPSHOT-2025-03-10-a

### DIFF
--- a/.github/workflows/swiftwasm.yml
+++ b/.github/workflows/swiftwasm.yml
@@ -5,13 +5,13 @@ on:
   pull_request:
     branches: ["wasm32-wasi-test"]
 env:
-  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-03-04-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-03-04-a-wasm32-unknown-wasi.artifactbundle.zip
-  SWIFT_SDK_CHECKSUM: 99e312607dfa5adaef2783e7079adc354c51e96a0b0b5a97d2be0953425b5990
+  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-03-10-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-03-10-a-wasm32-unknown-wasi.artifactbundle.zip
+  SWIFT_SDK_CHECKSUM: 9e35629b1ddc1b9402ff71b61520a563af2cecdc9295fb026db7546a3d7d4da4
   TARGET_TRIPLE: wasm32-unknown-wasi
 jobs:
   test:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-main-jammy@sha256:75ed181a139768455f5c480b0a76df89bed44ce92d26ee2fd5c7ca7b9a67d90e
+    container: swiftlang/swift:nightly-main-jammy@sha256:451bd701ac3d9cf59ffa7e1a95564dac3376510474afb707ff53d3f204fd45b3
     env:
       STACK_SIZE: 16777216
     steps:


### PR DESCRIPTION
https://github.com/swiftwasm/swift/releases/tag/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-03-10-a