### PR TITLE
ci: bump wasmtime to 34.0.0

### DIFF
--- a/.github/workflows/swiftwasm.yml
+++ b/.github/workflows/swiftwasm.yml
@@ -29,7 +29,7 @@ jobs:
         run: apt-get update && apt-get install --no-install-recommends -y xz-utils unzip
       - uses: bytecodealliance/actions/wasmtime/setup@v1
         with:
-          version: "33.0.0"
+          version: "34.0.0"
       - run: swift --version
       - run: wasmtime -V
       - run: swift sdk install ${{ matrix.target.sdk.url }} --checksum ${{ matrix.target.sdk.checksum }}


### PR DESCRIPTION
https://github.com/bytecodealliance/wasmtime/releases/tag/v34.0.0