### PR TITLE
ci: use wasmkit instead of wasmtime

### DIFF
--- a/.github/workflows/swiftwasm.yml
+++ b/.github/workflows/swiftwasm.yml
@@ -13,7 +13,7 @@ jobs:
               url: https://download.swift.org/development/wasm-sdk/swift-DEVELOPMENT-SNAPSHOT-2025-07-23-a/swift-DEVELOPMENT-SNAPSHOT-2025-07-23-a_wasm.artifactbundle.tar.gz
               checksum: cdf60771229f08108c41f1ca1464dbff94c6d69fdaef10ffa278fca2601969e4
               id: swift-DEVELOPMENT-SNAPSHOT-2025-07-23-a_wasm
-            other-wasmtime-flags:
+            other-wasmkit-flags:
     runs-on: ubuntu-24.04-arm
     env:
       STACK_SIZE: 16777216
@@ -24,11 +24,7 @@ jobs:
         run: |
           curl --silent --retry 3 --location --fail --compressed https://swift.org/keys/all-keys.asc | gpg --import -
           swiftly install -y --use main-snapshot-2025-07-23
-      - uses: bytecodealliance/actions/wasmtime/setup@v1
-        with:
-          version: "35.0.0"
       - run: swift --version
-      - run: wasmtime -V
       - run: swift sdk install ${{ matrix.target.sdk.url }} --checksum ${{ matrix.target.sdk.checksum }}
       - run: swift build -c release --build-tests --swift-sdk ${{ matrix.target.sdk.id }} -Xlinker -z -Xlinker stack-size=$STACK_SIZE
-      - run: wasmtime --dir / --wasm max-wasm-stack=$STACK_SIZE ${{ matrix.target.other-wasmtime-flags }} .build/release/swift-syntaxPackageTests.xctest
+      - run: wasmkit run --dir .build --dir / --stack-size=$STACK_SIZE ${{ matrix.target.other-wasmkit-flags }} .build/release/swift-syntaxPackageTests.xctest


### PR DESCRIPTION
WasmKit is fast. Also, it's included in Swift toolchains, so it's easy to use.