### PR TITLE
ci: bump Swift SDK to swift-DEVELOPMENT-SNAPSHOT-2025-07-23-a_wasm

### DIFF
--- a/.github/workflows/swiftwasm.yml
+++ b/.github/workflows/swiftwasm.yml
@@ -9,16 +9,11 @@ jobs:
     strategy:
       matrix:
         target:
-          - triple: wasm32-unknown-wasi
-            sdk:
-              url: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-07-18-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-07-18-a-wasm32-unknown-wasi.artifactbundle.zip
-              checksum: 249e8fc0dd6bc5e31583d6c63c778830ff0e3b9f98cff7ee6b31b2decf5f87cb
+          - sdk:
+              url: https://download.swift.org/development/wasm-sdk/swift-DEVELOPMENT-SNAPSHOT-2025-07-23-a/swift-DEVELOPMENT-SNAPSHOT-2025-07-23-a_wasm.artifactbundle.tar.gz
+              checksum: cdf60771229f08108c41f1ca1464dbff94c6d69fdaef10ffa278fca2601969e4
+              id: swift-DEVELOPMENT-SNAPSHOT-2025-07-23-a_wasm
             other-wasmtime-flags:
-          - triple: wasm32-unknown-wasip1-threads
-            sdk:
-              url: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-07-18-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-07-18-a-wasm32-unknown-wasip1-threads.artifactbundle.zip
-              checksum: 9d273f7b5e26bffa284a386833bb1675a04c7e177f67c58725fea41c1bc63f5a
-            other-wasmtime-flags: --wasi threads
     runs-on: ubuntu-24.04-arm
     env:
       STACK_SIZE: 16777216
@@ -28,12 +23,12 @@ jobs:
       - name: swiftly install
         run: |
           curl --silent --retry 3 --location --fail --compressed https://swift.org/keys/all-keys.asc | gpg --import -
-          swiftly install -y --use main-snapshot-2025-07-18
+          swiftly install -y --use main-snapshot-2025-07-23
       - uses: bytecodealliance/actions/wasmtime/setup@v1
         with:
           version: "35.0.0"
       - run: swift --version
       - run: wasmtime -V
       - run: swift sdk install ${{ matrix.target.sdk.url }} --checksum ${{ matrix.target.sdk.checksum }}
-      - run: swift build -c release --build-tests --swift-sdk ${{ matrix.target.triple }} -Xlinker -z -Xlinker stack-size=$STACK_SIZE
+      - run: swift build -c release --build-tests --swift-sdk ${{ matrix.target.sdk.id }} -Xlinker -z -Xlinker stack-size=$STACK_SIZE
       - run: wasmtime --dir / --wasm max-wasm-stack=$STACK_SIZE ${{ matrix.target.other-wasmtime-flags }} .build/release/swift-syntaxPackageTests.xctest


### PR DESCRIPTION
Swift SDK for Wasm is now published on swift.org, but it doesn't seem to have an SDK for wasm32-wasip1-threads.